### PR TITLE
fitLev, startPos and memory leak fix

### DIFF
--- a/src/bikeRender.js
+++ b/src/bikeRender.js
@@ -1,0 +1,312 @@
+function hypot(a, b) {
+  return Math.sqrt(a * a + b * b);
+}
+
+// (x1, y1)–(x2, y2): line to draw image along
+// bx: length of image used before (x1, y1)
+// br: length of image used after (x2, y2)
+// by: proportional (of ih) y offset within the image the line is conceptually along
+// ih: image height
+function skewimage(canv, img, bx, by, br, ih, x1, y1, x2, y2, box) {
+  var o = x2 - x1,
+    a = y2 - y1;
+  canv.save();
+  canv.translate(x1, y1);
+  canv.rotate(Math.atan2(a, o));
+  canv.translate(-bx, -by * ih);
+  canv.scale(bx + br + hypot(o, a), ih);
+  img.draw(canv);
+  if (box) {
+    canv.strokeStyle = "purple";
+    canv.lineWidth = 0.02;
+    canv.strokeRect(0, 0, 1, 1);
+  }
+  canv.restore();
+}
+
+function limb(cwInner, fstParams, sndParams) {
+  return function(canv, fstImg, x1, y1, sndImg, x2, y2) {
+    var dist = hypot(x2 - x1, y2 - y1);
+    var fstLen = fstParams.length,
+      sndLen = sndParams.length;
+
+    var prod =
+      (dist + fstLen + sndLen) *
+      (dist - fstLen + sndLen) *
+      (dist + fstLen - sndLen) *
+      (-dist + fstLen + sndLen);
+    var angle = Math.atan2(y2 - y1, x2 - x1);
+    var jointangle = 0;
+    if (prod >= 0 && dist < fstLen + sndLen) {
+      // law of sines
+      var circumr = dist * fstLen * sndLen / Math.sqrt(prod);
+      jointangle = Math.asin(sndLen / (2 * circumr));
+    } else fstLen = fstLen / (fstLen + sndLen) * dist;
+
+    if (cwInner) jointangle *= -1;
+
+    var jointx = x1 + fstLen * Math.cos(angle + jointangle);
+    var jointy = y1 + fstLen * Math.sin(angle + jointangle);
+
+    skewimage(
+      canv,
+      fstImg,
+      fstParams.bx,
+      fstParams.by,
+      fstParams.br,
+      fstParams.ih,
+      jointx,
+      jointy,
+      x1,
+      y1
+    );
+    skewimage(
+      canv,
+      sndImg,
+      sndParams.bx,
+      sndParams.by,
+      sndParams.br,
+      sndParams.ih,
+      x2,
+      y2,
+      jointx,
+      jointy
+    );
+  };
+}
+
+var legLimb = limb(
+  false,
+  {
+    length: 26.25 / 48,
+    bx: 0,
+    by: 0.6,
+    br: 6 / 48,
+    ih: 39.4 / 48 / 3
+  },
+  {
+    length: 1 - 26.25 / 48,
+    bx: 5 / 48 / 3,
+    by: 0.45,
+    br: 4 / 48,
+    ih: 60 / 48 / 3
+  }
+);
+
+var armLimb = limb(
+  true,
+  {
+    length: 0.3234,
+    bx: 12.2 / 48 / 3,
+    by: 0.5,
+    br: 13 / 48 / 3,
+    ih: -32 / 48 / 3
+  },
+  {
+    length: 0.3444,
+    bx: 3 / 48,
+    by: 0.5,
+    br: 13.2 / 48 / 3,
+    ih: 22.8 / 48 / 3
+  }
+);
+
+function wheel(canv, lgr, wheelX, wheelY, wheelR) {
+  canv.save();
+  canv.translate(wheelX, -wheelY);
+  canv.rotate(-wheelR);
+  canv.scale(38.4 / 48, 38.4 / 48);
+  canv.translate(-0.5, -0.5);
+  lgr.wheel.draw(canv);
+  canv.restore();
+}
+
+function turnScale(x) {
+  return -Math.cos(x * Math.PI);
+}
+
+const defaultBikeCoords = {
+  bikeR: 10000,
+  turn: 0,
+  leftX: -849.4,
+  leftY: -600.6,
+  rightX: 849,
+  rightY: -600,
+  rightR: 0.42,
+  headX: 0,
+  headY: 439,
+  lastTurnF: -1,
+  lv: null,
+};
+
+// extracted from recRender so we can draw a bike in start position when there's no replay
+export default function bikeRender(canv, lgr, shirt, frame, x, y, scale, startX, startY, bikeCoords) {
+  canv.save();
+  canv.translate(
+    scale * (-x + startX),
+    scale * (-y - startY)
+  );
+  canv.scale(scale, scale);
+  canv.beginPath();
+
+  var coords = bikeCoords ? bikeCoords : defaultBikeCoords;
+
+  var bikeR = coords.bikeR * Math.PI * 2 / 10000;
+  var turn = coords.turn;
+  var leftX = coords.leftX / 1000;
+  var leftY = coords.leftY / 1000;
+  var leftR = coords.leftR * Math.PI * 2 / 250;
+  var rightX = coords.rightX / 1000;
+  var rightY = coords.rightY / 1000;
+  var rightR = coords.rightR * Math.PI * 2 / 250;
+  var headX = coords.headX / 1000;
+  var headY = coords.headY / 1000;
+  var lastTurnF = coords.lastTurnF;
+  var lv = coords.lv;
+
+  var animlen = 28;
+  var animpos =
+    lv != null && frame - lv[0] < animlen ? (frame - lv[0]) / animlen : 0;
+  var turnpos =
+    lastTurnF >= 0 && lastTurnF + 24 > frame ? (frame - lastTurnF) / 24 : 0;
+
+  var backX = !turn ? rightX : leftX;
+  var backY = !turn ? rightY : leftY;
+  var backR = !turn ? rightR : leftR;
+  var frontX = turn ? rightX : leftX;
+  var frontY = turn ? rightY : leftY;
+  var frontR = turn ? rightR : leftR;
+
+  if (turnpos == 0 || turnpos > 0.5) wheel(canv, lgr, backX, backY, backR);
+  if (turnpos <= 0.5) wheel(canv, lgr, frontX, frontY, frontR);
+
+  canv.save();
+  canv.rotate(-bikeR);
+  if (turn) canv.scale(-1, 1);
+  if (turnpos > 0) canv.scale(turnScale(turnpos), 1);
+
+  var wx, wy, a, r;
+  var hbarsX = -21.5,
+    hbarsY = -17;
+  canv.save();
+  canv.scale(1 / 48, 1 / 48);
+
+  // front suspension
+  wx = turn ? rightX : leftX;
+  wy = turn ? -rightY : -leftY;
+  a = Math.atan2(wy, (turn ? -1 : 1) * wx) + (turn ? -1 : 1) * bikeR;
+  r = hypot(wx, wy);
+  skewimage(
+    canv,
+    lgr.susp1,
+    2,
+    0.5,
+    5,
+    6,
+    48 * r * Math.cos(a),
+    48 * r * Math.sin(a),
+    hbarsX,
+    hbarsY
+  );
+
+  // rear suspension
+  wx = turn ? leftX : rightX;
+  wy = turn ? -leftY : -rightY;
+  a = Math.atan2(wy, (turn ? -1 : 1) * wx) + (turn ? -1 : 1) * bikeR;
+  r = hypot(wx, wy);
+  //skewimage(canv, lgr.susp2, 5, 0.5, 5, 6.5, 48*r*Math.cos(a), 48*r*Math.sin(a), 10, 20);
+  skewimage(
+    canv,
+    lgr.susp2,
+    0,
+    0.5,
+    5,
+    6,
+    9,
+    20,
+    48 * r * Math.cos(a),
+    48 * r * Math.sin(a)
+  );
+  canv.restore();
+
+  canv.save(); // bike
+  canv.translate(-43 / 48, -12 / 48);
+  canv.rotate(-Math.PI * 0.197);
+  canv.scale(0.215815 * 380 / 48, 0.215815 * 301 / 48);
+  lgr.bike.draw(canv);
+  canv.restore();
+
+  canv.save(); // kuski
+  r = hypot(headX, headY);
+  a = Math.atan2(-headY, turn ? -headX : headX) + (turn ? -bikeR : bikeR);
+  wx = r * Math.cos(a);
+  wy = r * Math.sin(a);
+  canv.translate(wx, wy);
+
+  canv.save(); // head
+  canv.translate(-15.5 / 48, -42 / 48);
+  canv.scale(23 / 48, 23 / 48);
+  lgr.head.draw(canv);
+  canv.restore();
+
+  var bumx = 19.5 / 48,
+    bumy = 0;
+  var pedalx = -wx + 10.2 / 48 / 3,
+    pedaly = -wy + 65 / 48 / 3;
+  legLimb(canv, lgr.q1thigh, bumx, bumy, lgr.q1leg, pedalx, pedaly);
+
+  canv.save(); // torso
+  canv.translate(17 / 48, 9.25 / 48);
+  canv.rotate(Math.PI + 2 / 3);
+  canv.scale(100 / 48 / 3, 58 / 48 / 3);
+  if (shirt && shirt.touch()) {
+    // assumes shirts are rotated as on EOL site
+    canv.translate(0.5, 0.5);
+    canv.rotate(Math.PI / 2);
+    canv.translate(-0.5, -0.5);
+    shirt.draw(canv);
+  } else lgr.q1body.draw(canv);
+  canv.restore();
+
+  var shoulderx = 0 / 48,
+    shouldery = -17.5 / 48;
+  var handlex = -wx - 64.5 / 48 / 3,
+    handley = -wy - 59.6 / 48 / 3;
+  var handx = handlex,
+    handy = handley;
+
+  var animx = shoulderx,
+    animy = shouldery;
+  if (animpos > 0) {
+    var dangle, ascale;
+    if (lv[1] == turn) {
+      if (animpos >= 0.25) animpos = 0.25 - 0.25 * (animpos - 0.25) / 0.75;
+      dangle = 10.8 * animpos;
+      ascale = 1 - 1.2 * animpos;
+    } else {
+      if (animpos >= 0.2) animpos = 0.2 - 0.2 * (animpos - 0.2) / 0.8;
+      dangle = -8 * animpos;
+      ascale = 1 + 0.75 * animpos;
+    }
+    var at = Math.atan2(handley - animy, handlex - animx) + dangle;
+    var dist = ascale * hypot(handley - animy, handlex - animx);
+    handx = animx + dist * Math.cos(at);
+    handy = animy + dist * Math.sin(at);
+  }
+
+  armLimb(
+    canv,
+    lgr.q1up_arm,
+    shoulderx,
+    shouldery,
+    lgr.q1forarm,
+    handx,
+    handy
+  );
+  canv.restore();
+  canv.restore();
+
+  if (turnpos != 0 && turnpos <= 0.5) wheel(canv, lgr, backX, backY, backR);
+  if (turnpos > 0.5) wheel(canv, lgr, frontX, frontY, frontR);
+  canv.restore();
+}

--- a/src/levRender.js
+++ b/src/levRender.js
@@ -555,6 +555,9 @@ export default function levRender(reader, lgr) {
       canv.translate(-x, 0);
       img.repeat(canv, w + img.width, h);
       canv.restore();
+    },
+    bounds: function() {
+      return { minX, minY, maxX, maxY };
     }
   };
 }

--- a/src/player.js
+++ b/src/player.js
@@ -40,6 +40,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
   var optPictures = true;
   var optCustomBackgroundSky = true;
 
+  var bounds = null;
+
   reset();
 
   lgr.afterLoad(function() {
@@ -77,6 +79,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
     zoom = 0;
     speed = 1;
 
+    bounds = null;
+
     defaultObjRn = objRender(levRd);
   }
 
@@ -93,7 +97,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
         offsY: 0,
         // hack! Firefox seems to perform a lot better without the cache
         // suspect it has to do with the offscreen antialiasing it's doing
-        levRn: isMozilla ? levRn.draw : levRn.cached(4, makeCanvas)
+        levRn: isMozilla ? levRn.draw : levRn.cached(4, makeCanvas),
+        scaleFac: 1
       };
     return viewports[n];
   }
@@ -174,8 +179,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
       update: function(cx, cy) {
         dragging = true;
         invalidate = true;
-        vp.offsX = firstOx - (cx - x) / (48 * getScale());
-        vp.offsY = firstOy - (cy - y) / (48 * getScale());
+        vp.offsX = firstOx - (cx - x) / (vp.scaleFac * 48 * getScale());
+        vp.offsY = firstOy - (cy - y) / (vp.scaleFac * 48 * getScale());
       },
 
       end: function() {}
@@ -208,10 +213,32 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
   }
 
   function changeFocus() {
+    focus = true;
+    bounds = null;
     invalidate = true;
     if (replays.length > 0) replays.unshift(replays.pop());
+    resetViewports();
     for (var z = 0; z < viewports.length; z++)
       viewports[z].offsX = viewports[z].offsY = 0;
+  }
+
+  function unfocus() {
+		focus = false;
+		invalidate = true;
+		resetViewports();
+	}
+
+  function fitLev() {
+		bounds = levRn.bounds();
+		setScale(1);
+		invalidate = true;
+		resetViewports();
+	}
+
+  function resetViewports() {
+    for (var z = 0; z < viewports.length; z++) {
+      viewports[z].offsX = viewports[z].offsY = 0;
+    }
   }
 
   function playPause() {
@@ -244,16 +271,24 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
 
     var centreX = vp.offsX,
       centreY = vp.offsY;
-    if (topRec) {
+    if (bounds != null) {
+      centreX += (bounds.maxX + bounds.minX)/2;
+      centreY += (bounds.maxY + bounds.minY)/2;
+      var bw = bounds.maxX - bounds.minX;
+      var bh = bounds.maxY - bounds.minY;
+      vp.scaleFac = Math.min(w/bw, h/bh)/48;
+    } else if (topRec) {
       var lf = Math.min(frame, topRec.rd.frameCount() - 1);
       centreX += topRec.rn.bikeXi(lf);
       centreY -= topRec.rn.bikeYi(lf);
+      vp.scaleFac = 1;
     } else {
       centreX += startX;
       centreY += startY;
+      vp.scaleFac = 1;
     }
 
-    var escale = 48 * getScale();
+    var escale = vp.scaleFac * 48 * getScale();
     var ex = eround(centreX - w / escale / 2),
       ey = eround(centreY - h / escale / 2);
     var ew = eround(w / escale),
@@ -422,6 +457,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
     },
 
     changeFocus: changeFocus,
+    unfocus: unfocus,
+    fitLev: fitLev,
 
     setSpeed: setSpeed,
     setScale: setScale,
@@ -471,6 +508,9 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
           break;
         case "backspace":
           setSpeed(signum(speed));
+          break;
+        case "f":
+          fitLev();
           break;
         case "w":
           setZoom(zoom + 1);

--- a/src/player.js
+++ b/src/player.js
@@ -100,7 +100,9 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
         offsY: 0,
         // hack! Firefox seems to perform a lot better without the cache
         // suspect it has to do with the offscreen antialiasing it's doing
-        levRn: isMozilla ? levRn.draw : levRn.cached(4, makeCanvas),
+        // levRn: isMozilla ? levRn.draw : levRn.cached(4, makeCanvas),
+        // this "hack" caused major memory leak
+        levRn: levRn.cached(4, makeCanvas),
         scaleFac: 1
       };
     return viewports[n];

--- a/src/player.js
+++ b/src/player.js
@@ -1,6 +1,7 @@
 import levRender from "./levRender";
 import recRender from "./recRender";
 import objRender from "./objRender";
+import bikeRender from "./bikeRender";
 
 var isMozilla =
   typeof navigator != "undefined" &&
@@ -41,6 +42,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
   var optCustomBackgroundSky = true;
 
   var bounds = null;
+
+  var showStartPos = false;
 
   reset();
 
@@ -235,6 +238,10 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
 		resetViewports();
 	}
 
+  function startPos() {
+    showStartPos = true;
+  }
+
   function resetViewports() {
     for (var z = 0; z < viewports.length; z++) {
       viewports[z].offsX = viewports[z].offsY = 0;
@@ -296,6 +303,9 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
 
     levRn.drawSky(canv, ex, ey, ew, eh, escale);
     vp.levRn(canv, ex, ey, ew, eh, escale);
+    if (replays.length === 0 && showStartPos) {
+      bikeRender(canv, lgr, null, 0, ex, ey, escale, startX + 0.84, Math.abs(startY - 0.6));
+    }
     if (focus && replays.length > 0)
       replays[0].objRn.draw(
         canv,
@@ -459,6 +469,7 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
     changeFocus: changeFocus,
     unfocus: unfocus,
     fitLev: fitLev,
+    startPos: startPos,
 
     setSpeed: setSpeed,
     setScale: setScale,

--- a/src/recRender.js
+++ b/src/recRender.js
@@ -1,28 +1,4 @@
-function hypot(a, b) {
-  return Math.sqrt(a * a + b * b);
-}
-
-// (x1, y1)–(x2, y2): line to draw image along
-// bx: length of image used before (x1, y1)
-// br: length of image used after (x2, y2)
-// by: proportional (of ih) y offset within the image the line is conceptually along
-// ih: image height
-function skewimage(canv, img, bx, by, br, ih, x1, y1, x2, y2, box) {
-  var o = x2 - x1,
-    a = y2 - y1;
-  canv.save();
-  canv.translate(x1, y1);
-  canv.rotate(Math.atan2(a, o));
-  canv.translate(-bx, -by * ih);
-  canv.scale(bx + br + hypot(o, a), ih);
-  img.draw(canv);
-  if (box) {
-    canv.strokeStyle = "purple";
-    canv.lineWidth = 0.02;
-    canv.strokeRect(0, 0, 1, 1);
-  }
-  canv.restore();
-}
+import bikeRender from "./bikeRender";
 
 function target(canv, x, y, s) {
   canv.beginPath();
@@ -32,93 +8,6 @@ function target(canv, x, y, s) {
   canv.lineTo(x, y + s / 2);
   canv.stroke();
 }
-
-function limb(cwInner, fstParams, sndParams) {
-  return function(canv, fstImg, x1, y1, sndImg, x2, y2) {
-    var dist = hypot(x2 - x1, y2 - y1);
-    var fstLen = fstParams.length,
-      sndLen = sndParams.length;
-
-    var prod =
-      (dist + fstLen + sndLen) *
-      (dist - fstLen + sndLen) *
-      (dist + fstLen - sndLen) *
-      (-dist + fstLen + sndLen);
-    var angle = Math.atan2(y2 - y1, x2 - x1);
-    var jointangle = 0;
-    if (prod >= 0 && dist < fstLen + sndLen) {
-      // law of sines
-      var circumr = dist * fstLen * sndLen / Math.sqrt(prod);
-      jointangle = Math.asin(sndLen / (2 * circumr));
-    } else fstLen = fstLen / (fstLen + sndLen) * dist;
-
-    if (cwInner) jointangle *= -1;
-
-    var jointx = x1 + fstLen * Math.cos(angle + jointangle);
-    var jointy = y1 + fstLen * Math.sin(angle + jointangle);
-
-    skewimage(
-      canv,
-      fstImg,
-      fstParams.bx,
-      fstParams.by,
-      fstParams.br,
-      fstParams.ih,
-      jointx,
-      jointy,
-      x1,
-      y1
-    );
-    skewimage(
-      canv,
-      sndImg,
-      sndParams.bx,
-      sndParams.by,
-      sndParams.br,
-      sndParams.ih,
-      x2,
-      y2,
-      jointx,
-      jointy
-    );
-  };
-}
-
-var legLimb = limb(
-  false,
-  {
-    length: 26.25 / 48,
-    bx: 0,
-    by: 0.6,
-    br: 6 / 48,
-    ih: 39.4 / 48 / 3
-  },
-  {
-    length: 1 - 26.25 / 48,
-    bx: 5 / 48 / 3,
-    by: 0.45,
-    br: 4 / 48,
-    ih: 60 / 48 / 3
-  }
-);
-
-var armLimb = limb(
-  true,
-  {
-    length: 0.3234,
-    bx: 12.2 / 48 / 3,
-    by: 0.5,
-    br: 13 / 48 / 3,
-    ih: -32 / 48 / 3
-  },
-  {
-    length: 0.3444,
-    bx: 3 / 48,
-    by: 0.5,
-    br: 13.2 / 48 / 3,
-    ih: 22.8 / 48 / 3
-  }
-);
 
 export default function recRender(reader) {
   var turnFrames = (function() {
@@ -220,172 +109,20 @@ export default function recRender(reader) {
   // (x, y): top left in Elma coordinates
   // arguably a microoptimisation, but it doesn't produce any objects in the JS world
   function draw(canv, lgr, shirt, frame, x, y, scale) {
-    canv.save();
-    canv.translate(
-      /*Math.ceil*/ scale * (-x + bikeXi(frame)),
-      /*Math.ceil*/ scale * (-y - bikeYi(frame))
-    );
-    canv.scale(scale, scale);
-    canv.beginPath();
-
-    var bikeR = bikeRi(frame) * Math.PI * 2 / 10000;
-    var turn = (reader.turn(Math.floor(frame)) >> 1) & 1;
-    var leftX = leftXi(frame) / 1000;
-    var leftY = leftYi(frame) / 1000;
-    var leftR = leftRi(frame) * Math.PI * 2 / 250;
-    var rightX = rightXi(frame) / 1000;
-    var rightY = rightYi(frame) / 1000;
-    var rightR = rightRi(frame) * Math.PI * 2 / 250;
-    var headX = headXi(frame) / 1000;
-    var headY = headYi(frame) / 1000;
-    var lastTurnF = lastTurn(frame);
-    var lv = lastVolt(frame);
-
-    var animlen = 28;
-    var animpos =
-      lv != null && frame - lv[0] < animlen ? (frame - lv[0]) / animlen : 0;
-    var turnpos =
-      lastTurnF >= 0 && lastTurnF + 24 > frame ? (frame - lastTurnF) / 24 : 0;
-
-    var backX = !turn ? rightX : leftX;
-    var backY = !turn ? rightY : leftY;
-    var backR = !turn ? rightR : leftR;
-    var frontX = turn ? rightX : leftX;
-    var frontY = turn ? rightY : leftY;
-    var frontR = turn ? rightR : leftR;
-
-    if (turnpos == 0 || turnpos > 0.5) wheel(canv, lgr, backX, backY, backR);
-    if (turnpos <= 0.5) wheel(canv, lgr, frontX, frontY, frontR);
-
-    canv.save();
-    canv.rotate(-bikeR);
-    if (turn) canv.scale(-1, 1);
-    if (turnpos > 0) canv.scale(turnScale(turnpos), 1);
-
-    var wx, wy, a, r;
-    var hbarsX = -21.5,
-      hbarsY = -17;
-    canv.save();
-    canv.scale(1 / 48, 1 / 48);
-
-    // front suspension
-    wx = turn ? rightX : leftX;
-    wy = turn ? -rightY : -leftY;
-    a = Math.atan2(wy, (turn ? -1 : 1) * wx) + (turn ? -1 : 1) * bikeR;
-    r = hypot(wx, wy);
-    skewimage(
-      canv,
-      lgr.susp1,
-      2,
-      0.5,
-      5,
-      6,
-      48 * r * Math.cos(a),
-      48 * r * Math.sin(a),
-      hbarsX,
-      hbarsY
-    );
-
-    // rear suspension
-    wx = turn ? leftX : rightX;
-    wy = turn ? -leftY : -rightY;
-    a = Math.atan2(wy, (turn ? -1 : 1) * wx) + (turn ? -1 : 1) * bikeR;
-    r = hypot(wx, wy);
-    //skewimage(canv, lgr.susp2, 5, 0.5, 5, 6.5, 48*r*Math.cos(a), 48*r*Math.sin(a), 10, 20);
-    skewimage(
-      canv,
-      lgr.susp2,
-      0,
-      0.5,
-      5,
-      6,
-      9,
-      20,
-      48 * r * Math.cos(a),
-      48 * r * Math.sin(a)
-    );
-    canv.restore();
-
-    canv.save(); // bike
-    canv.translate(-43 / 48, -12 / 48);
-    canv.rotate(-Math.PI * 0.197);
-    canv.scale(0.215815 * 380 / 48, 0.215815 * 301 / 48);
-    lgr.bike.draw(canv);
-    canv.restore();
-
-    canv.save(); // kuski
-    r = hypot(headX, headY);
-    a = Math.atan2(-headY, turn ? -headX : headX) + (turn ? -bikeR : bikeR);
-    wx = r * Math.cos(a);
-    wy = r * Math.sin(a);
-    canv.translate(wx, wy);
-
-    canv.save(); // head
-    canv.translate(-15.5 / 48, -42 / 48);
-    canv.scale(23 / 48, 23 / 48);
-    lgr.head.draw(canv);
-    canv.restore();
-
-    var bumx = 19.5 / 48,
-      bumy = 0;
-    var pedalx = -wx + 10.2 / 48 / 3,
-      pedaly = -wy + 65 / 48 / 3;
-    legLimb(canv, lgr.q1thigh, bumx, bumy, lgr.q1leg, pedalx, pedaly);
-
-    canv.save(); // torso
-    canv.translate(17 / 48, 9.25 / 48);
-    canv.rotate(Math.PI + 2 / 3);
-    canv.scale(100 / 48 / 3, 58 / 48 / 3);
-    if (shirt && shirt.touch()) {
-      // assumes shirts are rotated as on EOL site
-      canv.translate(0.5, 0.5);
-      canv.rotate(Math.PI / 2);
-      canv.translate(-0.5, -0.5);
-      shirt.draw(canv);
-    } else lgr.q1body.draw(canv);
-    canv.restore();
-
-    var shoulderx = 0 / 48,
-      shouldery = -17.5 / 48;
-    var handlex = -wx - 64.5 / 48 / 3,
-      handley = -wy - 59.6 / 48 / 3;
-    var handx = handlex,
-      handy = handley;
-
-    var animx = shoulderx,
-      animy = shouldery;
-    if (animpos > 0) {
-      var dangle, ascale;
-      if (lv[1] == turn) {
-        if (animpos >= 0.25) animpos = 0.25 - 0.25 * (animpos - 0.25) / 0.75;
-        dangle = 10.8 * animpos;
-        ascale = 1 - 1.2 * animpos;
-      } else {
-        if (animpos >= 0.2) animpos = 0.2 - 0.2 * (animpos - 0.2) / 0.8;
-        dangle = -8 * animpos;
-        ascale = 1 + 0.75 * animpos;
-      }
-      var at = Math.atan2(handley - animy, handlex - animx) + dangle;
-      var dist = ascale * hypot(handley - animy, handlex - animx);
-      handx = animx + dist * Math.cos(at);
-      handy = animy + dist * Math.sin(at);
-    }
-
-    armLimb(
-      canv,
-      lgr.q1up_arm,
-      shoulderx,
-      shouldery,
-      lgr.q1forarm,
-      handx,
-      handy
-    );
-    canv.restore();
-    canv.restore();
-
-    if (turnpos != 0 && turnpos <= 0.5) wheel(canv, lgr, backX, backY, backR);
-    if (turnpos > 0.5) wheel(canv, lgr, frontX, frontY, frontR);
-    canv.restore();
+    var bikeCoords = {};
+    bikeCoords.bikeR = bikeRi(frame);
+    bikeCoords.turn = (reader.turn(Math.floor(frame)) >> 1) & 1;
+    bikeCoords.leftX = leftXi(frame);
+    bikeCoords.leftY = leftYi(frame);
+    bikeCoords.leftR = leftRi(frame);
+    bikeCoords.rightX = rightXi(frame);
+    bikeCoords.rightY = rightYi(frame);
+    bikeCoords.rightR = rightRi(frame);
+    bikeCoords.headX = headXi(frame);
+    bikeCoords.headY = headYi(frame);
+    bikeCoords.lastTurnF = lastTurn(frame);
+    bikeCoords.lv = lastVolt(frame);
+    bikeRender(canv, lgr, shirt, frame, x, y, scale, bikeXi(frame), bikeYi(frame), bikeCoords);
   }
 
   return {


### PR DESCRIPTION
1. direct port of the fitLev feature made in the OG repo https://github.com/Maxdamantus/recplay/commit/48200bbb8faf27b41d4caabd40dc96c8e8fa708b
2. show start position when there's no replay, this may seem like a bigger change than it is, just had to extract the draw feature from bikeRender to own file so it could be used without a replay
3. there was some condition to check for firefox and skip using the cached function, this seems to have caused the memory leak, avoiding this is more important at least than whatever that hack was fixing