### PR TITLE
refactor to load recs and change rec

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -199,29 +199,43 @@ export default function(
 
           recNames.map(function(r) {
             return get(r, function(rec) {
-              pl.addReplay(recReader(rec), [loadedShirt[0]]);
+              pl.addReplay(recReader(rec), r, [loadedShirt[0]]);
               loadedShirt = loadedShirt.slice(1);
             });
           });
         },
 
         changeReplays: function(recNames, shirts) {
-          let loadedShirt = !shirts
-            ? []
-            : shirts.map(function(s) {
+            const loadedRecs = pl.loadedRecs();
+
+            loadedRecs.forEach(function(r) {
+              if (!recNames.includes(r)) {
+                pl.removeReplay(r);
+              }
+            });
+
+            const newRecs = [];
+            const newShirts = [];
+
+            recNames.forEach(function(r, i) {
+              if (loadedRecs.includes(r)) {
+                return;
+              }
+
+              newRecs.push(r);
+              newShirts.push(shirts[i]);
+            });
+
+            let loadedShirt = newShirts.map(function(s) {
               return s == null ? null : pllgr.lazy(s);
             });
 
-            pl.clearReplays();
-
-            recNames.map(function(r) {
+            newRecs.map(function(r) {
               return get(r, function(rec) {
-                pl.addReplay(recReader(rec), [loadedShirt[0]]);
+                pl.addReplay(recReader(rec), r, [loadedShirt[0]]);
                 loadedShirt = loadedShirt.slice(1);
               });
             });
-
-          pl.changeReplays(readRecs, loadedShirt);
         },
 
         removeAnimationLoop: function() {

--- a/src/controller.js
+++ b/src/controller.js
@@ -190,6 +190,40 @@ export default function(
           });
         },
 
+        loadReplays: function(recNames, shirts) {
+          let loadedShirt = !shirts
+            ? []
+            : shirts.map(function(s) {
+              return s == null ? null : pllgr.lazy(s);
+            });
+
+          recNames.map(function(r) {
+            return get(r, function(rec) {
+              pl.addReplay(recReader(rec), [loadedShirt[0]]);
+              loadedShirt = loadedShirt.slice(1);
+            });
+          });
+        },
+
+        changeReplays: function(recNames, shirts) {
+          let loadedShirt = !shirts
+            ? []
+            : shirts.map(function(s) {
+              return s == null ? null : pllgr.lazy(s);
+            });
+
+            pl.clearReplays();
+
+            recNames.map(function(r) {
+              return get(r, function(rec) {
+                pl.addReplay(recReader(rec), [loadedShirt[0]]);
+                loadedShirt = loadedShirt.slice(1);
+              });
+            });
+
+          pl.changeReplays(readRecs, loadedShirt);
+        },
+
         removeAnimationLoop: function() {
           play = false;
           animationLoop && window.clearInterval(animationLoop);

--- a/src/player.js
+++ b/src/player.js
@@ -488,6 +488,12 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
       invalidate = true;
     },
 
+    clearReplays: function() {
+      lastFrame = 0;
+      setRef();
+      replay.subs = [];
+    },
+
     changeFocus: changeFocus,
     unfocus: unfocus,
     fitLev: fitLev,

--- a/src/player.js
+++ b/src/player.js
@@ -464,12 +464,8 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
     },
 
     // shirts should be created by lgr.lazy
-    addReplay: function(recRd, shirts) {
-      if (replays.length == 0) {
-        lastFrame = 0;
-        setRef();
-      }
-      var replay = { objRn: objRender(levRd, recRd), subs: [] };
+    addReplay: function(recRd, recName, shirts) {
+      var replay = { recName: recName, objRn: objRender(levRd, recRd), subs: [] };
       while (recRd) {
         replay.subs.push({
           rd: recRd,
@@ -485,13 +481,18 @@ export default function(levRd, lgr, makeCanvas, autoPlay) {
       }, 0);
       replays.push(replay);
       frameCount = calcFrameCount();
-      invalidate = true;
     },
 
-    clearReplays: function() {
-      lastFrame = 0;
-      setRef();
-      replay.subs = [];
+    removeReplay: function(recName) {
+      replays = replays.filter(function(r) {
+        return r.recName !== recName;
+      });
+    },
+
+    loadedRecs: function() {
+      return replays.map(function(r) {
+        return r.recName
+      });
     },
 
     changeFocus: changeFocus,


### PR DESCRIPTION
Implements two new methods on recplayer controller: loadReplays and changeReplays.

The addReplay in the replay was already kinda working for this scenario except it would reset to frame 0 forcefully.

Recplayer-react can now pass recs and shirts as it seems fit and recplayer will figure it out. So all recplayer-react has to do when getting an update to which recs to display it will call changeReplays and initially it can call either loadReplay or loadReplays.